### PR TITLE
Fix docs for by-method

### DIFF
--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -380,10 +380,10 @@ directive:
 
 [source, clojure]
 ----
-(ct/routes [:prefix "api"
-            [:by-method "users"
-             [:get list-users-handler]
-             [:post create-users-handler]]])
+(ct/routes [:prefix "api/users"
+            [:by-method
+             {:get list-users-handler
+              :post create-users-handler}]])
 ----
 
 


### PR DESCRIPTION
It took me a while before I realized what I was doing wrong with the
by-method route directive untill I checked your test and saw that the
docs where out of date. This commit fixes the docs for by-method