### PR TITLE
Bugfix chaining by method

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject funcool/catacumba "0.8.0"
+(defproject funcool/catacumba "0.8.1-SNAPSHOT"
   :description "Asynchronous Web Toolkit for Clojure."
   :url "http://github.com/funcool/catacumba"
   :license {:name "BSD (2-Clause)"

--- a/src/clojure/catacumba/impl/routing.clj
+++ b/src/clojure/catacumba/impl/routing.clj
@@ -71,7 +71,7 @@
   [^Chain chain [_ handlersmap]]
   {:pre [(map? handlersmap)]}
   (letfn [(attach [^Context ctx ^ByMethodSpec spec [method handler]]
-            (let [^Handler handler (hs/adapter handler)
+            (let [^Handler handler (if (vector? handler) (combine-handlers handler) (hs/adapter handler))
                   ^Block block (hp/fn->block #(.handle handler ctx))]
               (case method
                 :get (.get spec block)


### PR DESCRIPTION
allows devs add multiple handlers in the by-method:

```
[:by-method
 {:get [FIRST SECOND THIRD]}]
```