### PR TITLE
Add catacumba.handlers.logging & tests

### DIFF
--- a/src/clojure/catacumba/handlers/logging.clj
+++ b/src/clojure/catacumba/handlers/logging.clj
@@ -1,0 +1,51 @@
+;; Copyright (c) 2015 Andrey Antukh <niwi@niwi.nz>
+;; All rights reserved.
+;;
+;; Redistribution and use in source and binary forms, with or without
+;; modification, are permitted provided that the following conditions are met:
+;;
+;; * Redistributions of source code must retain the above copyright notice, this
+;;   list of conditions and the following disclaimer.
+;;
+;; * Redistributions in binary form must reproduce the above copyright notice,
+;;   this list of conditions and the following disclaimer in the documentation
+;;   and/or other materials provided with the distribution.
+;;
+;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+;; DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+;; FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+;; DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+;; SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+;; CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+;; OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+;; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+(ns catacumba.handlers.logging
+  "Request logging."
+  (:require [catacumba.impl.context :as ct]
+            [catacumba.core :refer [on-close]])
+  (:import ratpack.handling.RequestLogger
+           ratpack.handling.RequestOutcome
+           ratpack.http.Status))
+
+(defn- status->map [^Status status]
+  {:code (.getCode status)
+   :message (.getMessage status)})
+
+(defn- outcome->map [^RequestOutcome outcome]
+  (let [response (.getResponse outcome)]
+    {:headers  (ct/headers->map
+                (.. response getHeaders asMultiValueMap)
+                true)
+     :status   (status->map (.getStatus response))
+     :sent-at  (.getSentAt outcome)
+     :duration (.getDuration outcome)}))
+
+(defn log
+  ([] (RequestLogger/ncsa))
+  ([log-fn]
+   (fn [context]
+     (on-close context #(log-fn context (outcome->map %)))
+     (ct/delegate))))

--- a/src/clojure/catacumba/impl/context.clj
+++ b/src/clojure/catacumba/impl/context.clj
@@ -171,11 +171,8 @@
   [^DefaultContext context]
   (get-route-params* (:catacumba/context context)))
 
-(defn get-headers*
-  [^Request request keywordize]
-  (let [^Headers headers (.getHeaders request)
-        ^MultiValueMap headers (.asMultiValueMap headers)]
-    (persistent!
+(defn headers->map [^MultiValueMap headers keywordize]
+  (persistent!
      (reduce (fn [acc ^String key]
                (let [values (.getAll headers key)
                      key (if keywordize
@@ -183,7 +180,12 @@
                            (.toLowerCase key))]
                  (reduce #(hp/assoc-conj! %1 key %2) acc values)))
              (transient {})
-             (.keySet headers)))))
+             (.keySet headers))))
+
+(defn get-headers*
+  [^Request request keywordize]
+  (let [^Headers headers (.getHeaders request)]
+    (headers->map (.asMultiValueMap headers) keywordize)))
 
 (defn get-headers
   [^DefaultContext context]


### PR DESCRIPTION
Resolves #35 

Let me know how much sense this makes.  If a function is passed to `logging/log`, it will receive two arguments - the context, and a map derived from the outcome, which looks like:

```clojure
{:sent-at  #object[java.time.Instant 0x634f0c73 "2015-11-08T13:55:09.373Z"],
 :duration #object[java.time.Duration 0x7dcb9b1 "PT0.001S"],
 :headers  {:content-type "text/plain;charset=UTF-8" ...},
 :status   {:code 200, :message "OK"}}
```

I am obviously more than happy to transform or nest these values in whichever way you prefer, or pass the handler a single map which also contains some keys obtained from the context (request headers, path, etc).