### PR TITLE
fix stop when there is not a server

### DIFF
--- a/src/clojure/catacumba/components.clj
+++ b/src/clojure/catacumba/components.clj
@@ -42,7 +42,7 @@
       (assoc component :server (run-server handler options))))
 
   (stop [component]
-    (.stop ^RatpackServer server)
+    (when server (.stop ^RatpackServer server))
     (assoc component :server nil)))
 
 (alter-meta! #'->Server assoc :private true)


### PR DESCRIPTION
sometimes when you are developing you brake the code and you should allow to stop your component even it has not been started