### PR TITLE
support for application/edn in body-params handler

### DIFF
--- a/src/clojure/catacumba/handlers/parse.clj
+++ b/src/clojure/catacumba/handlers/parse.clj
@@ -26,9 +26,12 @@
   (:require [catacumba.impl.context :as ctx]
             [promesa.core :as p]
             [cheshire.core :as json]
-            [cognitect.transit :as transit])
+            [cognitect.transit :as transit]
+            [clojure.edn :as edn])
   (:import ratpack.http.TypedData
-           ratpack.handling.Context))
+           ratpack.handling.Context
+           (java.io InputStreamReader
+                    PushbackReader)))
 
 (defmulti parse-body
   "A polymorophic method for parse body into clojure
@@ -66,6 +69,13 @@
   [^Context ctx ^TypedData body]
   (let [reader (transit/reader (.getInputStream body) :msgpack)]
     (transit/read reader)))
+
+(defmethod parse-body :application/edn
+  [^Context ctx ^TypedData body]
+  (edn/read {:eof nil :readers *data-readers*}
+            (-> (.getInputStream body)
+                (InputStreamReader. "UTF-8")
+                (PushbackReader.))))
 
 ;; --- Handlers
 

--- a/test/catacumba/handlers_tests.clj
+++ b/test/catacumba/handlers_tests.clj
@@ -131,6 +131,18 @@
         (let [headers {:content-type "application/transit+json"}
               response (client/get base-url headers)]
           (is (= nil (deref p 1000 :nothing)))))))
+
+  (testing "EDN encoded body parsing using chain handler"
+    (let [p (promise)
+          app (ct/routes [[:any (parse/body-params)]
+                          [:any #(do
+                                   (deliver p (:data %))
+                                   "hello world")]])]
+      (with-server {:handler app}
+        (let [params {:body (pr-str [1 2 3])
+                      :content-type "application/edn"}
+              response (client/post base-url params)]
+          (is (= [1 2 3] (deref p 1000 nil)))))))
   )
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -543,6 +555,3 @@
       (let [response (client/get base-url)]
         (is (= (:body response) "hello world cps"))
         (is (= (:status response) 200))))))
-
-
-


### PR DESCRIPTION
I noticed that application/edn is not supported out-of-the-box