### PR TITLE
Add functionality of being able to bind to a different IP

### DIFF
--- a/src/clojure/catacumba/impl/server.clj
+++ b/src/clojure/catacumba/impl/server.clj
@@ -39,7 +39,8 @@
            ratpack.ssl.SSLContexts
            ratpack.func.Action
            ratpack.func.Function
-           java.nio.file.Path))
+           java.nio.file.Path
+           java.net.InetAddress))
 
 (defn- bootstrap-registry
   "A bootstrap server hook for setup initial
@@ -64,7 +65,7 @@
 
 (defn- build-config
   "Given user specified options, return a `ServerConfig` instance."
-  [{:keys [port debug threads basedir public-address
+  [{:keys [port debug threads basedir public-address address
            max-body-size marker-file]
     :or {debug false marker-file ".catacumba.basedir"}
     :as options}]
@@ -83,6 +84,7 @@
         (catch IllegalStateException e
           ;; Excplicitly ignore this exception
           )))
+    (when address (.address config (InetAddress/getByName address)))
     (when sslcontext (.ssl config sslcontext))
     (when public-address (.publicAddress config (java.net.URI. public-address)))
     (when max-body-size (.maxContentLength config max-body-size))
@@ -105,6 +107,7 @@
   to the supplied options:
 
   - `:port`: the port to listen on (defaults to 5050).
+  - `:address`: the ip address to listen on (defaults to localhost).
   - `:threads`: the number of threads (default: number of cores * 2).
   - `:debug`: start in development mode or not (default: `true`).
   - `:setup`: callback for add additional entries in ratpack registry.

--- a/test/catacumba/core_tests.clj
+++ b/test/catacumba/core_tests.clj
@@ -32,7 +32,7 @@
         handler (fn [context]
                   (deliver p (ct/public-address context))
                   "hello world")]
-    (with-server {:handler handler}
+    (with-server {:handler handler :address "::0"}
       (let [response (client/get base-url)
             uri (deref p 1000 nil)]
         (is (= (str uri) "http://localhost:5050"))))))


### PR DESCRIPTION
Hello there,
I needed to be able to also bind to a different IP (rather than just "::0").
I looked for the solution in the code and couldn't find it!
I'm not sure if this patch matches your policy on the syntax or the tests but I tried my best, If it doesn't then let me know how I can improve it.
Thanks.